### PR TITLE
Allow to customize the alert before presenting it

### DIFF
--- a/CZPhotoPickerController/CZPhotoPickerController.h
+++ b/CZPhotoPickerController/CZPhotoPickerController.h
@@ -59,6 +59,12 @@ typedef void (^CZPhotoPickerCompletionBlock)(UIImagePickerController *imagePicke
 @property(nonatomic,strong) UIView *sourceView;
 
 /**
+ The block will be called right before the UIAlertController is presented. Use it if you need \
+ to add some custom options to the alert.
+ */
+@property(nonatomic,copy) void (^willPresentAlertController)(UIAlertController *);
+
+/**
  @param completionBlock Called when a photo has been picked or cancelled (`imageInfoDict` will be `nil` if canceled).
  If `UIImagePickerController` is set, it is your responsibility to dismiss it.
  */

--- a/CZPhotoPickerController/CZPhotoPickerController.m
+++ b/CZPhotoPickerController/CZPhotoPickerController.m
@@ -264,6 +264,10 @@ typedef NS_ENUM (NSUInteger, PhotoPickerButtonKind) {
       self.completionBlock(nil, nil);
     }]];
 
+    if (self.willPresentAlertController) {
+      self.willPresentAlertController(controller);
+    }
+
     [fromViewController presentViewController:controller animated:YES completion:nil];
 
   };


### PR DESCRIPTION
Closes #20 

@fatuhoku would you mind to give it a try?

If you are using CocoaPods, then in your Podfile do:

```ruby
pod 'CZPhotoPickerController', :git => 'https://github.com/carezone/CZPhotoPickerController.git', :commit => '486e6e5'
```

and re-run `pod install`.

Thanks in advance.


